### PR TITLE
Add explicit fastapi[standard] to Modal image

### DIFF
--- a/api/modal_app.py
+++ b/api/modal_app.py
@@ -3,6 +3,7 @@ import modal
 app = modal.App("ctc-calculator")
 
 image = modal.Image.debian_slim(python_version="3.12").pip_install(
+    "fastapi[standard]",
     "policyengine-us",
 )
 


### PR DESCRIPTION
## Summary
- Modal no longer auto-installs FastAPI for `@modal.web_endpoint` functions — it must be declared explicitly in `pip_install`
- Without this, the Modal app fails to deploy with: "Web endpoint Functions require FastAPI to be installed in their Image"

## Test plan
- [x] Modal deploy succeeds: `https://policyengine--ctc-calculator-calculate.modal.run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)